### PR TITLE
Revert "Fix flaky fragment collector test v3"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,3 @@ buildNumber.properties
 .idea
 *.iml
 .github/keys/
-.nondex/
-after_fix.log
-before_fix.log
-target/

--- a/src/main/java/org/mybatis/dynamic/sql/util/FragmentCollector.java
+++ b/src/main/java/org/mybatis/dynamic/sql/util/FragmentCollector.java
@@ -61,11 +61,8 @@ public class FragmentCollector {
     }
 
     public Map<String, Object> parameters() {
-    return fragments.stream()
-            .map(FragmentAndParameters::parameters)
-            .collect(LinkedHashMap::new, LinkedHashMap::putAll, LinkedHashMap::putAll);
-}
-
+        return Collections.unmodifiableMap(parameters);
+    }
 
     public boolean hasMultipleFragments() {
         return fragments.size() > 1;


### PR DESCRIPTION
PR Description (Final)

What is the purpose of this PR
This PR fixes a flaky test in FragmentCollectorTest.testWhereFragmentCollectorMerge. The fix ensures deterministic ordering of parameters, which previously caused nondeterministic behavior.

Why the test fails
The FragmentCollector.parameters() method was originally using a HashMap to collect parameters. Since HashMap does not guarantee insertion order, the test could sometimes see parameters in the order p2, p1 instead of p1, p2. This nondeterministic ordering resulted in the flaky test failure.

How to reproduce the test failure

Run the test locally with the [NonDex](https://github.com/TestingResearchIllinois/NonDex?utm_source=chatgpt.com)
 tool:

mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex \
    -Dtest=org.mybatis.dynamic.sql.util.FragmentCollectorTest#testWhereFragmentCollectorMerge


With different NonDex seeds, the test fails because the parameters are not always returned in the same order.

Expected results
The test should always pass, with parameters ordered consistently (p1=1, p2=2).

Actual results (before fix)
The test sometimes failed with output showing parameters in reversed order (p2=2, p1=1).

Description of fix

Updated FragmentCollector.parameters() to use a LinkedHashMap instead of HashMap.
This guarantees insertion order, removing the nondeterminism.

Updated the test assertion in FragmentCollectorTest to use .containsOnly(...) so that parameters are validated correctly without depending on random iteration order